### PR TITLE
[feature] Add player rotation when attacking

### DIFF
--- a/Assets/Scenes/demo_map.unity
+++ b/Assets/Scenes/demo_map.unity
@@ -17524,6 +17524,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7571023224850178587, guid: 671e38b92bb5c4743b7f954de4945d9c,
+        type: 3}
+      propertyPath: maxHealth
+      value: 20
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 671e38b92bb5c4743b7f954de4945d9c, type: 3}
 --- !u!1001 &650994637

--- a/Assets/Scripts/Odyn/BasicAbility.cs
+++ b/Assets/Scripts/Odyn/BasicAbility.cs
@@ -59,6 +59,7 @@ public class BasicAbility : MonoBehaviour
         {
             timeSinceJump += Time.fixedDeltaTime;
             playerMovement.moveable = false;
+            turnWhenAttack();
             if (timeSinceJump > delay)
             {
                 Attack();
@@ -88,6 +89,18 @@ public class BasicAbility : MonoBehaviour
             rb.velocity = direction.normalized * projectileSpeed;
             rb.transform.right = rb.velocity;
             rb.transform.rotation = rb.transform.rotation * Quaternion.Euler( new Vector3(0, 0, -45));
+        }
+    }
+    //Makes player face the direction where you click attack
+    private void turnWhenAttack() 
+    {
+        if (direction.x > 0)
+        {
+            playerMovement.spriteRenderer.flipX = false;
+        }
+        else if (direction.x < 0)
+        {
+            playerMovement.spriteRenderer.flipX = true;
         }
     }
 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -7,11 +7,12 @@ public class PlayerMovement : MonoBehaviour
 {
     public float movespeed = 5.0f;
     public Rigidbody2D rb;
-    private SpriteRenderer spriteRenderer;
     Vector2 movement;
     public bool moveable = true;
-
     public Animator animator;
+
+    [HideInInspector]
+    public SpriteRenderer spriteRenderer;
 
     private void Start() 
     {
@@ -21,17 +22,7 @@ public class PlayerMovement : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        movement.x = Input.GetAxisRaw("Horizontal");
-        movement.y = Input.GetAxisRaw("Vertical");
-
-        if(Input.GetKeyDown(KeyCode.D))
-        {
-            transform.localRotation = Quaternion.Euler(0, 0, 0);
-        }
-        if(Input.GetKeyDown(KeyCode.A))
-        {
-            transform.localRotation = Quaternion.Euler(0, 180, 0);
-        } 
+        Move();
     }
 
     void FixedUpdate()
@@ -41,5 +32,23 @@ public class PlayerMovement : MonoBehaviour
             rb.MovePosition(rb.position + movement.normalized * movespeed * Time.fixedDeltaTime);
         }
         animator.SetFloat("Speed", (movement.normalized * movespeed * Time.fixedDeltaTime).magnitude * Convert.ToInt32(moveable));
+    }
+
+    void Move() 
+    {
+        movement.x = Input.GetAxisRaw("Horizontal"); //when moving right movement.x = 1 and left movement.x = -1
+        movement.y = Input.GetAxisRaw("Vertical");
+
+        //Don't turn when in attack animation, even if you are eg. holding "D" (moving right)
+        if (movement.x > 0 && !animator.GetCurrentAnimatorStateInfo(0).IsTag("attack"))
+        {
+            spriteRenderer.flipX = false;
+
+        }
+        if (movement.x < 0 && !animator.GetCurrentAnimatorStateInfo(0).IsTag("attack"))
+        {
+            spriteRenderer.flipX = true;
+
+        }
     }
 }


### PR DESCRIPTION
Implemented player rotation on Basic attack click. The player should now rotate towards where you click when attacking. The player still rotates based on moving direction when not attacking.
I had to modify the playerMovement script so the player stops rotating(from movement) when attacking.
Changed player rotation function using transform.rotation to just toggling horizontal flip when rotating.
Fix #35 