### PR TITLE
[Bugfix] boar charging through collidables

### DIFF
--- a/Assets/Scripts/Enemies/Boar.cs
+++ b/Assets/Scripts/Enemies/Boar.cs
@@ -13,6 +13,7 @@ public class Boar : Enemy
     private Vector3 targetLastPos;
     private Vector3 direction;
     private Collider2D hitPlayer;
+    private bool hitCollidable = false;
 
     protected override void attack()
     {
@@ -27,20 +28,22 @@ public class Boar : Enemy
         if (Time.time - lastTime > attackCooldown)
         {
             isAttacking = true;
-            transform.position = Vector2.MoveTowards(transform.position, transform.position + direction, chargeSpeed * Time.deltaTime);       
+            GetComponent<Rigidbody2D>().velocity = direction * chargeSpeed; 
 
         }
         //Stop charge attack when a certain ammount of time has passed
-        if (Time.time - lastAttackStartTime >= chargeDuration)
+        if (Time.time - lastAttackStartTime >= chargeDuration || hitCollidable)
         {
+            GetComponent<Rigidbody2D>().velocity = Vector2.zero;
             lastTime = Time.time;
             isAttacking = false;
+            hitCollidable = false;
             hitPlayer = null;
         }
     }
     //Handles player taking damage and player can't get hit more than once per attack
     private void OnTriggerEnter2D(Collider2D other)
-    {   
+    {
         if (other.gameObject.CompareTag("Player") && isAttacking && !(hitPlayer == other))
         {
             hitPlayer = other;
@@ -49,6 +52,10 @@ public class Boar : Enemy
                 other.GetComponent<PlayerActions>().playerTakeDamage(chargeDamage);
             }
 
+        }
+        else if (other.gameObject.CompareTag("Collidables")) //stop the charge attack if boar hit a collidable
+        {
+            hitCollidable = true;
         }
     }
 

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffbffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffff3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
Change the function responsible for moving the boar during charge to be physics-based
Made boar stop charge when hitting a collidable
Made enemyFeet layer ignore itself otherwise they push each other a lot

Fix #72 