### PR TITLE
[bugfix] add simple enemy avoidance

### DIFF
--- a/Assets/Scripts/Enemies/Boar.cs
+++ b/Assets/Scripts/Enemies/Boar.cs
@@ -22,7 +22,6 @@ public class Boar : Enemy
         boarMoveSpeed = Random.Range(moveSpeed - 1f, moveSpeed + 0.8f);
         moveSpeed = boarMoveSpeed;
         attackCooldown = 3.0f;
-        print(moveSpeed);
     }
     protected override void attack()
     {


### PR DESCRIPTION
Gave boar slightly random speed when they spawn so they don't stack as easily as they do now
Random.Range(moveSpeed - 1f, moveSpeed + 0.8f)

Fix #99 