### PR TITLE
[feature] Add upgrade to shadowstep that lower the cooldown

### DIFF
--- a/Assets/Prefabs/Enemies/Training_dummy.prefab
+++ b/Assets/Prefabs/Enemies/Training_dummy.prefab
@@ -148,7 +148,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   enemyName: Training_dummy
   moveSpeed: 0
-  maxHealth: 1000
+  maxHealth: 10000
   expValue: 0
   canBeKnockedBack: 0
   playerCharacter: {fileID: 0}
@@ -163,6 +163,7 @@ MonoBehaviour:
   isAlive: 0
   isFleeing: 0
   takeDamageSound: {fileID: 8300000, guid: 46a6dbb3bcadac94d8f167310b7f459a, type: 3}
+  deathSound: {fileID: 0}
 --- !u!82 &4337271079157899349
 AudioSource:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Upgrades/Special/decreaseCD.asset
+++ b/Assets/Prefabs/Upgrades/Special/decreaseCD.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15681278948c9194eb1d48a50de5b8d2, type: 3}
+  m_Name: decreaseCD
+  m_EditorClassIdentifier: 
+  name: Lower Cooldown
+  description: Decrease the cooldown of shadowstep by 1 second
+  upgradeID: 13
+  animator: {fileID: 9100000, guid: fd88fd29e56edb942a416bf35303cc51, type: 2}

--- a/Assets/Prefabs/Upgrades/Special/decreaseCD.asset.meta
+++ b/Assets/Prefabs/Upgrades/Special/decreaseCD.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f15097c9df1f5b14c8ed63c5e0d364a0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Upgrades/UpgradeDropper.prefab
+++ b/Assets/Prefabs/Upgrades/UpgradeDropper.prefab
@@ -57,5 +57,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: a60ae0cdb013c504aa5689b58028dda7, type: 2}
   - {fileID: 11400000, guid: 9bb843e5365056747a0f0ac15f933b85, type: 2}
   - {fileID: 11400000, guid: 2b679ac375b940b479ee44aeef243fc7, type: 2}
+  - {fileID: 11400000, guid: f15097c9df1f5b14c8ed63c5e0d364a0, type: 2}
   upgradePrefab: {fileID: 2022560821489476551, guid: a51adcfbf3bc21443a40bb922a68b663,
     type: 3}

--- a/Assets/Scripts/Odyn/PlayerClass.cs
+++ b/Assets/Scripts/Odyn/PlayerClass.cs
@@ -19,6 +19,7 @@ public class PlayerClass : MonoBehaviour
 
     // Keep track of how many upgrades have been given
     public int basicProjectileUpgrades = 0;
+    public int shadowStepUpgrades = 0;
 
     // Start is called before the first frame update
     void Start()
@@ -63,6 +64,11 @@ public class PlayerClass : MonoBehaviour
     public void increaseSpecialAoE()
     {
         specialAbility.upgradeAoeEffect();
+    }
+
+    public void decreaseCooldownShadowstep()
+    {
+        specialAbility.decreaseCooldown();
     }
 
     public void setUtilityDot()

--- a/Assets/Scripts/Odyn/SpecialAbility.cs
+++ b/Assets/Scripts/Odyn/SpecialAbility.cs
@@ -215,6 +215,14 @@ public class SpecialAbility : MonoBehaviour
         aoeRadius += 0.5f;
         areaOfEffect = true;
     }
+    // should not go lower than 1
+    public void decreaseCooldown()
+    {
+        if(cooldown > 1)
+        {
+            cooldown--;
+        }
+    }
 
     private Vector2 getPlayerPos(){
         return new Vector2(transform.position.x, transform.position.y);

--- a/Assets/Scripts/Odyn/Upgrades/GeneralUpgrade.cs
+++ b/Assets/Scripts/Odyn/Upgrades/GeneralUpgrade.cs
@@ -44,7 +44,7 @@ public class GeneralUpgrade : MonoBehaviour
                         break;
                     case 1:
                         player.increaseProjectiles(1);
-                        if (player.basicProjectileUpgrades == 5)
+                        if (player.basicProjectileUpgrades > 4)
                             upgradeDropper.remove(thisUpgrade);
                         break;
                     case 2:
@@ -85,6 +85,11 @@ public class GeneralUpgrade : MonoBehaviour
                     case 12:
                         player.setUtilityAttackToSides();
                         upgradeDropper.remove(thisUpgrade);
+                        break;
+                    case 13:
+                        player.decreaseCooldownShadowstep();
+                        if (player.shadowStepUpgrades > 2)
+                            upgradeDropper.remove(thisUpgrade);
                         break;
                     default:
                         break;

--- a/Assets/Scripts/PlayerActions.cs
+++ b/Assets/Scripts/PlayerActions.cs
@@ -92,6 +92,12 @@ public class PlayerActions : MonoBehaviour
     {
         if (moveable)
             playerFaceDirection();
+
+        //For demo purpose, to try out upgrades
+        if (Input.GetKeyDown("k"))
+        {
+            LevelUp();
+        }
     }
 
     private void FixedUpdate()
@@ -114,7 +120,7 @@ public class PlayerActions : MonoBehaviour
     {
         //Modify stats
         level += 1;
-        playerClass.increaseDamage(2);
+        playerClass.increaseDamage(0);
         playerClass.dropUpgrade(level);
 
         //Modify Exp values


### PR DESCRIPTION
Now there is an upgrade that lowers the cooldown of shadowstep by 1second
This upgrade can only be taken 3 times so the minimum cooldown is 2 seconds for the ability

Added so if you press "k" you will level up(so you can try upgrades)
Increased HP for the training dummy
Removed damage increase for player when leveling

Fix #179 