### PR TITLE
[bug] Add hashset solution to spawn unique upgrades

### DIFF
--- a/Assets/Scripts/Odyn/Upgrades/GeneralUpgrade.cs
+++ b/Assets/Scripts/Odyn/Upgrades/GeneralUpgrade.cs
@@ -7,7 +7,8 @@ using UnityEngine.Experimental.Rendering.LWRP;
 public class GeneralUpgrade : MonoBehaviour
 {
     private GameObject toolTip;
-    private Upgrade thisUpgrade;
+    [HideInInspector]
+    public Upgrade thisUpgrade;
     private UpgradeDropper upgradeDropper;
 
     public int dropIndex;
@@ -15,15 +16,11 @@ public class GeneralUpgrade : MonoBehaviour
     private void Start()
     {
         upgradeDropper = GameObject.Find("UpgradeDropper(Clone)").GetComponent<UpgradeDropper>(); 
-
-        // min is incluseive, max is exclusive
-        // picks a random upgrade for this instance from the list upgrades
-        thisUpgrade = upgradeDropper.upgrades[Random.Range(0, upgradeDropper.upgrades.Count)];
         
         toolTip = gameObject.transform.GetChild(0).gameObject;
         toolTip.transform.GetChild(1).GetComponent<TextMeshPro>().SetText(thisUpgrade.description, true);
         toolTip.transform.GetChild(2).GetComponent<TextMeshPro>().SetText(thisUpgrade.abilityName, true);
-        
+
         GetComponent<Animator>().runtimeAnimatorController = thisUpgrade.animator;
         StartCoroutine(decreaseLight());
     }

--- a/Assets/Scripts/Odyn/Upgrades/UpgradeDropper.cs
+++ b/Assets/Scripts/Odyn/Upgrades/UpgradeDropper.cs
@@ -25,7 +25,22 @@ public class UpgradeDropper : MonoBehaviour
         currentDrops[numDroppedUpgrades-1][0] = Instantiate(upgradePrefab, spawnPosition + offset, Quaternion.identity);
         currentDrops[numDroppedUpgrades-1][1] = Instantiate(upgradePrefab, spawnPosition + offset + new Vector2(3f,0), Quaternion.identity);
         currentDrops[numDroppedUpgrades-1][2] = Instantiate(upgradePrefab, spawnPosition + offset + new Vector2(-3f,0), Quaternion.identity);
-    
+
+        // Generates the upgrades in a way that all three are unique
+        HashSet<int> upgradeNumbers = new HashSet<int>();
+
+        while (upgradeNumbers.Count < 3)
+        {
+            upgradeNumbers.Add(Random.Range(0, upgrades.Count));
+        }
+
+        int pos = 0;
+        foreach (int number in upgradeNumbers)
+        {
+            currentDrops[numDroppedUpgrades-1][pos].thisUpgrade = upgrades[number];
+            pos++;
+        }
+
         // Tells all upgrades what order they were dropped in, so that we can remove the associated
         // upgrades when picking one up
         for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Generates 3 unique numbers and assign those to the spawned upgrades

Fix #197 